### PR TITLE
Fixed bug with API Gateway requiring JSON.parse to be used, but Lambd…

### DIFF
--- a/handleCreate/index.js
+++ b/handleCreate/index.js
@@ -11,7 +11,8 @@ const peopleSchema = new dynamoose.Schema({
 const personModel = dynamoose.model('people-demo', peopleSchema);
 
 exports.handler = async (event) => {
-  const { id, name, phone } = event.body;
+  const parsedBody = JSON.parse(event.body);
+  const { id, name, phone } = parsedBody;
   const person = { id, name, phone };
 
   const response = {

--- a/handleUpdate/index.js
+++ b/handleUpdate/index.js
@@ -11,8 +11,9 @@ const peopleSchema = new dynamoose.Schema({
 const personModel = dynamoose.model('people-demo', peopleSchema);
 
 exports.handler = async (event) => {
+  const parsedBody = JSON.parse(event.body);
   const id = event.pathParameters.id.toString();
-  const { name, phone } = event.body;
+  const { name, phone } = parsedBody;
   const person = { id, name, phone };
 
   const response = {


### PR DESCRIPTION
Fixed bug with API Gateway requiring JSON.parse to be used, but Lambda test events do not. Using JSON.parse now